### PR TITLE
introduce skip_cookie_file option

### DIFF
--- a/lib/inwx/domrobot.rb
+++ b/lib/inwx/domrobot.rb
@@ -4,7 +4,8 @@ module INWX
   class Domrobot
     attr_accessor :client, :cookie
 
-    def initialize(address)
+    def initialize(address, options = {})
+      @options = options
       @cookie = ""
       # Create a new client instance
       @client = XMLRPC::Client.new(address,"/xmlrpc/","443", nil, nil, nil, nil, true, 100)
@@ -26,20 +27,24 @@ module INWX
     
     def setCookie(cookie)
       self.cookie = cookie
-      fp = File.new("domrobot.tmp", "w")
-      fp.write(cookie)
-      fp.close
+      unless @options[:skip_cookie_file]
+        fp = File.new("domrobot.tmp", "w")
+        fp.write(cookie)
+        fp.close
+      end
     end
     
     def getCookie()
       if self.cookie.length > 2
         return self.cookie
       end
-      if File.exist?("domrobot.tmp")
-        fp = File.new("domrobot.tmp", "r")
-        cookie = fp.read()
-        fp.close
-        return cookie
+      unless @options[:skip_cookie_file]
+        if File.exist?("domrobot.tmp")
+          fp = File.new("domrobot.tmp", "r")
+          cookie = fp.read()
+          fp.close
+          return cookie
+        end
       end
     end
     


### PR DESCRIPTION
I was looking for a way to use the gem without storing cookie information in an extra file. For our current setup the file writing may cause some issues and just isn't necessary. That's why I created the possibility to skip this part.

Thought it could be useful for others, too, so here you have a pull request :)
